### PR TITLE
Clean up connection leaks in broker and offset coordinator

### DIFF
--- a/kafkatest/broker.go
+++ b/kafkatest/broker.go
@@ -243,3 +243,8 @@ func (c *OffsetCoordinator) Offset(topic string, partition int32) (offset int64,
 	}
 	return off, "", nil
 }
+
+func (c *OffsetCoordinator) Close() {
+	// No-op
+	return
+}


### PR DESCRIPTION
When fetching a new connection for the offset coordinator, the broker
would leak the connection used for the metadata request. Moreover, there
was no way to reclaim the connection used by an offset coordinator. We
cleaned up the connection leak and added a Close() method for the
coordinator which returns its connection to the broker's pool.
