### PR TITLE
Remove pointers to pool/metadata objs

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -204,8 +204,8 @@ type connectionPool struct {
 }
 
 // newConnectionPool creates a connection pool and initializes it.
-func newConnectionPool(conf BrokerConf) *connectionPool {
-	return &connectionPool{
+func newConnectionPool(conf BrokerConf) connectionPool {
+	return connectionPool{
 		conf:     conf,
 		mu:       &sync.RWMutex{},
 		backends: make(map[string]*backend),
@@ -352,6 +352,10 @@ func (cp *connectionPool) IsClosed() bool {
 // called in a goroutine so as not to block the original caller, as this function may take
 // some time to return.
 func (cp *connectionPool) Idle(conn *connection) {
+	if conn == nil {
+		return
+	}
+
 	if be := cp.getOrCreateBackend(conn.addr); be != nil {
 		be.Idle(conn)
 	} else {

--- a/metadata.go
+++ b/metadata.go
@@ -26,8 +26,8 @@ type clusterMetadata struct {
 	partitions map[string]int32         // topic to numer of partitions
 }
 
-func newClusterMetadata(conf BrokerConf, pool *connectionPool) *clusterMetadata {
-	result := &clusterMetadata{
+func newClusterMetadata(conf BrokerConf, pool *connectionPool) clusterMetadata {
+	result := clusterMetadata{
 		mu:      &sync.RWMutex{},
 		timeout: conf.MetadataRefreshTimeout,
 		refLock: &sync.Mutex{},


### PR DESCRIPTION
These objects are never unset and don't need to be pointers in the
broker object since we own them. This removes a mutex and some
pointers and additionally fixes a crash when Idle is called with a nil
connection.
