### PR TITLE
Connection pooling updates

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -2027,7 +2027,10 @@ func (s *BrokerSuite) TestOffsetCoordinatorNoCoordinatorError(c *C) {
 	c.Assert(err, IsNil)
 
 	coordConf := NewOffsetCoordinatorConf("test-group")
-	_, err = broker.OffsetCoordinator(coordConf)
+	oc, err := broker.OffsetCoordinator(coordConf)
+	c.Assert(err, IsNil)
+
+	err = oc.Commit("foo", int32(0), 10)
 	c.Assert(err, Equals, proto.ErrNoCoordinator)
 }
 


### PR DESCRIPTION
This fixes a bug where the OffsetCoordinator could, if it was
long-running, leak connections in the state where it had a connection at
startup, later that connection got an error so it made a new one (first
connection leaks), etc. This makes the process slightly less efficient
by always asking the broker for a connection but I think this will be a
lot safer than having the connection cached on the coordinator.

Additionally, I don't really want (infrequently used) coordinator
connections to hog up potentially valuable and limited connections we
might have open to our backends. It only takes a handful of coordinators
being created to really crimp your capacity.

Second, this diff makes it so that every time we run into the max
connections counter we will prune any closed connections from the
list. We don't actually need these closed connections and the point of
the limit is to limit _active/open_ connections to backends. Closed
connections don't matter so we should just remove them.

This has the (nice!) side effect of making any problems where we're
leaking connections show up somewhere else, hopefully closer to where
the leak is happening (stalled goroutine etc) rather than the problem
manifesting as connection pool issues.
