### PR TITLE
Remove dead backends in InitializeAddrs.

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -985,7 +985,7 @@ func (s *BrokerSuite) TestPartitionOffsetClosedConnection(c *C) {
 	c.Assert(handlerErr, IsNil)
 	c.Assert(err, IsNil)
 	c.Assert(offset, Equals, int64(123))
-	c.Assert(len(broker.conns.addrs), Equals, 2)
+	c.Assert(len(broker.conns.backends), Equals, 2)
 
 	srv1.Close()
 

--- a/connection_pool_test.go
+++ b/connection_pool_test.go
@@ -83,3 +83,15 @@ func (s *ConnectionPoolSuite) TestConnectionLimit(c *C) {
 	cp.Idle(conn)
 	c.Assert(be.NumOpenConnections(), Equals, 0)
 }
+
+func (s *ConnectionPoolSuite) TestTrimDeadAddrs(c *C) {
+	cp := newConnectionPool(NewBrokerConf("foo"))
+	cp.InitializeAddrs([]string{"foo", "bar", "baz"})
+	c.Assert(len(cp.GetAllAddrs()), Equals, 3)
+	c.Assert(cp.getBackend("foo"), Not(IsNil))
+	c.Assert(cp.getBackend("qux"), IsNil)
+	cp.InitializeAddrs([]string{"qux"})
+	c.Assert(len(cp.GetAllAddrs()), Equals, 1)
+	c.Assert(cp.getBackend("qux"), Not(IsNil))
+	c.Assert(cp.getBackend("foo"), IsNil)
+}


### PR DESCRIPTION
cc @zorkian 

It turns out InitializeAddrs only expands the set of backends and never shrinks it. e.g. today in prod we have machines attempting to connect to long-removed brokers.

I intentionally didn't squash these two commits because the 2nd is pretty obviously correct given the 1st, but taken together they might be harder to follow.
