### PR TITLE
Make tests work in Windows

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -26,7 +26,7 @@ type serializableMessage interface {
 }
 
 func testServer(messages ...serializableMessage) (net.Listener, error) {
-	ln, err := net.Listen("tcp", "")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func testServer(messages ...serializableMessage) (net.Listener, error) {
 }
 
 func testServer2() (net.Listener, chan serializableMessage, error) {
-	ln, err := net.Listen("tcp", "")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,7 +94,7 @@ func testServer2() (net.Listener, chan serializableMessage, error) {
 }
 
 func testServer3() (net.Listener, error) {
-	ln, err := net.Listen("tcp", "")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}

--- a/kafkatest/server.go
+++ b/kafkatest/server.go
@@ -228,7 +228,7 @@ func (s *Server) MustSpawn() {
 		return
 	}
 
-	ln, err := net.Listen("tcp4", ":0")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		panic(fmt.Sprintf("cannot listen: %s", err))
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -81,7 +81,7 @@ func (srv *Server) Start() {
 	if srv.ln != nil {
 		panic("server already started")
 	}
-	ln, err := net.Listen("tcp4", "")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		panic(fmt.Sprintf("cannot start server: %s", err))
 	}


### PR DESCRIPTION
This just forces us to use 127.0.0.1 for tests instead of relying on "all interfaces". This should also still work in Linux.
