### PR TITLE
Release waiters on close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -170,6 +170,10 @@ func (c *connection) Close() error {
 	if c.stopErr == nil {
 		c.stopErr = ErrClosed
 		close(c.stop)
+
+		for correlationID, _ := range c.respc {
+			go c.releaseWaiter(correlationID)
+		}
 	}
 	return c.rw.Close()
 }

--- a/metadata.go
+++ b/metadata.go
@@ -43,7 +43,7 @@ func newClusterMetadata(conf BrokerConf, pool *connectionPool) clusterMetadata {
 				select {
 				case <-time.After(conf.MetadataRefreshFrequency):
 					log.Info("Initiating periodic metadata refresh.")
-					result.Refresh()
+					go result.Fetch()
 				case <-pool.ClosedChan():
 					log.Info("Aborting periodic metadata refresh due to closed connection pool.")
 					return


### PR DESCRIPTION
This diff also upgrades the periodic metadata refresh into an actual Fetch call. This means that if the change in connection.go doesn't actually fix the issue, we should still be able to get fresh metadata every hour (the default for the refresh period).