### PR TITLE
Simplify connection library

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -1875,7 +1875,9 @@ func (s *BrokerSuite) TestProducerBrokenPipe(c *C) {
 	srv2.Start()
 
 	host1, port1 := srv1.HostPort()
+	log.Infof("server1 %s:%d", host1, port1)
 	host2, port2 := srv2.HostPort()
+	log.Infof("server2 %s:%d", host2, port2)
 
 	srv1.Handle(MetadataRequest, func(request Serializable) Serializable {
 		req := request.(*proto.MetadataReq)

--- a/log_test.go
+++ b/log_test.go
@@ -15,9 +15,13 @@ type logTestBackend struct {
 
 var logTest = &logTestBackend{mu: &sync.Mutex{}}
 
-func init() {
+func logInit() {
 	logMu.Lock()
 	defer logMu.Unlock()
+
+	if log != nil {
+		return
+	}
 
 	log = logging.MustGetLogger("KafkaClient")
 	log.SetBackend(logging.AddModuleLevel(logTest))

--- a/proto/messages.go
+++ b/proto/messages.go
@@ -58,6 +58,10 @@ const (
 	CompressionSnappy Compression = 2
 )
 
+type Request interface {
+	WriteTo(io.Writer) (int64, error)
+}
+
 // ReadReq returns request kind ID and byte representation of the whole message
 // in wire protocol format.
 func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {

--- a/proto/messages_test.go
+++ b/proto/messages_test.go
@@ -16,20 +16,20 @@ func Test(t *testing.T) { TestingT(t) }
 
 type MessagesSuite struct{}
 
-type Request interface {
+type TestRequest interface {
 	Bytes() ([]byte, error)
 	WriteTo(w io.Writer) (int64, error)
 }
 
-var _ Request = &MetadataReq{}
-var _ Request = &ProduceReq{}
-var _ Request = &FetchReq{}
-var _ Request = &GroupCoordinatorReq{}
-var _ Request = &OffsetReq{}
-var _ Request = &OffsetCommitReq{}
-var _ Request = &OffsetFetchReq{}
+var _ TestRequest = &MetadataReq{}
+var _ TestRequest = &ProduceReq{}
+var _ TestRequest = &FetchReq{}
+var _ TestRequest = &GroupCoordinatorReq{}
+var _ TestRequest = &OffsetReq{}
+var _ TestRequest = &OffsetCommitReq{}
+var _ TestRequest = &OffsetFetchReq{}
 
-func testRequestSerialization(c *C, r Request) {
+func testRequestSerialization(c *C, r TestRequest) {
 	var buf bytes.Buffer
 	if n, err := r.WriteTo(&buf); err != nil {
 		c.Fatalf("could not write request to buffer: %s", err)


### PR DESCRIPTION
This doesn't need any goroutines or fancy stuff. Since connection pool
guarantees we never hand out a connection to more than one 'owner', we
can ensure that connections are treated in never used across threads and
can drastically clean this up.