### PR TITLE
Use -1 time

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1011,9 +1011,9 @@ func (c *offsetCoordinator) commit(
 	// message at offset 0.
 	if offset < 0 {
 		return fmt.Errorf("Cannot commit negative offset %d for [%s:%d].",
-			offset, topic, partition)	
+			offset, topic, partition)
 	}
-	
+
 	retry := &backoff.Backoff{Min: c.conf.RetryErrWait, Jitter: true}
 	for try := 0; try < c.conf.RetryErrLimit; try++ {
 		if try != 0 {
@@ -1036,7 +1036,7 @@ func (c *offsetCoordinator) commit(
 				{
 					Name: topic,
 					Partitions: []proto.OffsetCommitReqPartition{
-						{ID: partition, Offset: offset, TimeStamp: time.Now(), Metadata: metadata},
+						{ID: partition, Offset: offset, Metadata: metadata},
 					},
 				},
 			},
@@ -1126,7 +1126,7 @@ func (c *offsetCoordinator) Offset(
 					// but adding debugging in the meantime.
 					if p.Offset < 0 {
 						log.Errorf("negative offset response %d for %s:%d",
-				  			p.Offset, t.Name, p.ID)	
+							p.Offset, t.Name, p.ID)
 					}
 					return p.Offset, p.Metadata, nil
 				}

--- a/proto/messages.go
+++ b/proto/messages.go
@@ -884,7 +884,7 @@ func (r *OffsetCommitReq) Bytes() ([]byte, error) {
 		for _, part := range topic.Partitions {
 			enc.Encode(part.ID)
 			enc.Encode(part.Offset)
-			enc.Encode(int64(0))
+			enc.Encode(int64(-1)) // -1 is "use current time"
 			enc.Encode(part.Metadata)
 		}
 	}


### PR DESCRIPTION
This causes Kafka to use the 'current' timestamp for the committed
offset. The value of 0 would cause Kafka to expire the offset in
the next stale offset purge, which effectively meant offsets were
disappearing.