### PR TITLE
Clarify NoPartitionsAvailable error string

### DIFF
--- a/distributing_producer.go
+++ b/distributing_producer.go
@@ -68,7 +68,7 @@ type errorAverseRRProducer struct {
 type NoPartitionsAvailable struct{}
 
 func (NoPartitionsAvailable) Error() string {
-	return "No partitions available within timeout."
+	return "All partitions suspended due to previous failures, refusing to attempt the produce."
 }
 
 func NewErrorAverseRRProducer(conf *errorAverseRRProducerConf) DistributingProducer {


### PR DESCRIPTION
Customer gave feedback that it ought to be more clear that this is an internal error message and not a part of the Kafka protocol.