### PR TITLE
Swap constant values of StartOffset

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -15,13 +15,13 @@ import (
 )
 
 const (
-	// StartOffsetNewest configures the consumer to fetch messages produced
-	// after creating the consumer.
-	StartOffsetNewest = -1
-
 	// StartOffsetOldest configures the consumer to fetch starting from the
 	// oldest message available.
-	StartOffsetOldest = -2
+	StartOffsetOldest = -1
+	
+	// StartOffsetNewest configures the consumer to fetch messages produced
+	// after creating the consumer.
+	StartOffsetNewest = -2
 )
 
 var (


### PR DESCRIPTION
In theory this diff is a no-op because nobody should be providing negative offset integers outside the use of these constants. Unfortunately it turns out there's no real way to make these type safe without making them into structs because constants are untyped until a type is required, meaning that integer literals can be used in place of the iota constant you really wanted to force people to use.