### PR TITLE
Fix connection pool timeout case

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -119,7 +119,8 @@ type BrokerConf struct {
 	// Defaults to False.
 	AllowTopicCreation bool
 
-	// Any new connection dial timeout.
+	// Any new connection dial timeout. This must be at least double the
+	// IdleConnectionWait.
 	//
 	// Default is 10 seconds.
 	DialTimeout time.Duration
@@ -166,7 +167,8 @@ type BrokerConf struct {
 
 	// IdleConnectionWait sets a timeout on how long we should wait for a connection to
 	// become idle before we establish a new one. This value sets a cap on how much latency
-	// you're willing to add to a request before establishing a new connection.
+	// you're willing to add to a request before establishing a new connection. This must
+	// be less than half the DialTimeout.
 	//
 	// Default is 200ms.
 	IdleConnectionWait time.Duration

--- a/connection.go
+++ b/connection.go
@@ -83,6 +83,9 @@ func (c *connection) sendRequest(req proto.Request, reqID int32) (*bytes.Reader,
 	}()
 	select {
 	case result := <-readRespChan:
+		if result.err != nil {
+			c.Close()
+		}
 		return result.bytes, result.err
 	case <-time.After(2 * c.timeout):
 		c.Close()
@@ -95,6 +98,7 @@ func (c *connection) sendRequest(req proto.Request, reqID int32) (*bytes.Reader,
 // receiving the response.
 func (c *connection) sendRequestHelper(req proto.Request, reqID int32) (
 	*bytes.Reader, error) {
+
 	if _, err := req.WriteTo(c.rw); err != nil {
 		log.Errorf("cannot write: %s", err)
 		return nil, err

--- a/server_test.go
+++ b/server_test.go
@@ -100,12 +100,13 @@ func (srv *Server) Start() {
 
 func (srv *Server) Close() {
 	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
 	_ = srv.ln.Close()
 	for _, cli := range srv.clients {
 		_ = cli.Close()
 	}
 	srv.clients = make(map[int64]net.Conn)
-	srv.mu.Unlock()
 }
 
 func (srv *Server) handleClient(c net.Conn) {


### PR DESCRIPTION
When a broker becomes unavailable and we are failing to connect to it
(dial timeout or connection error) we need to propogate that message
up as the result of GetConnection so that the caller knows something
happened that wasn't a transient issue.

The broken behavior right now doesn't propogate the message which causes
metadata to never be refreshed when a broker goes down.