### PR TITLE
Extend timeout for RefreshMetadata to try all the brokers

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -181,7 +181,7 @@ func (cm *Cluster) RefreshMetadata() error {
 	select {
 	case err := <-updateChan:
 		return err
-	case <-time.After(cm.getTimeout() * len(cm.metadataConnPool.GetAllAddrs())):
+	case <-time.After(cm.getTimeout()):
 		return errors.New("timed out refreshing metadata")
 	}
 }
@@ -197,9 +197,11 @@ func (cm *Cluster) Fetch(clientId string, topics ...string) (*proto.MetadataResp
 	// Get all addresses, then walk the array in permuted random order.
 	addrs := cm.metadataConnPool.GetAllAddrs()
 	log.Infof("metadata fetch addrs: %s", addrs)
+	// split the timeout so that we can try getting the metadata from more than one broker.
+	perBrokerTimeout := cm.getTimeout() / 2
 	for _, idx := range rndPerm(len(addrs)) {
 		// Directly connect, ignoring connection pool limits. This connection must be closed here.
-		conn, err := newTCPConnection(addrs[idx], cm.getTimeout())
+		conn, err := newTCPConnection(addrs[idx], perBrokerTimeout)
 		if err != nil {
 			log.Warningf("metadata fetch failed to connect to node %s: %s", addrs[idx], err)
 			continue

--- a/cluster.go
+++ b/cluster.go
@@ -181,7 +181,7 @@ func (cm *Cluster) RefreshMetadata() error {
 	select {
 	case err := <-updateChan:
 		return err
-	case <-time.After(cm.getTimeout()):
+	case <-time.After(cm.getTimeout() * len(cm.metadataConnPool.GetAllAddrs())):
 		return errors.New("timed out refreshing metadata")
 	}
 }


### PR DESCRIPTION
It doesn't make sense to have the timeout for RefreshMetadata to be the
same as the timeout for each request in Fetch if Fetch is going to try
all the brokers (line 202)
