### PR TITLE
Add log level flag

### DIFF
--- a/kafkatest/log.go
+++ b/kafkatest/log.go
@@ -1,13 +1,21 @@
 package kafkatest
 
 import (
+	"flag"
 	"sync"
 
 	"github.com/op/go-logging"
 )
 
-var log *logging.Logger
-var logMu = &sync.Mutex{}
+var (
+	log *logging.Logger
+	logMu = &sync.Mutex{}
+
+	logLevel = flag.Int(
+		"kafkatest.log_level",
+		int(logging.INFO),
+		"Set logging verbosity for kafkatest package.")
+)
 
 func init() {
 	logMu.Lock()
@@ -17,7 +25,7 @@ func init() {
 		return
 	}
 	log = logging.MustGetLogger("KafkaTest")
-	logging.SetLevel(logging.INFO, "KafkaTest")
+	logging.SetLevel(logging.Level(*logLevel), "KafkaTest")
 }
 
 func SetLogger(l *logging.Logger) {

--- a/log.go
+++ b/log.go
@@ -1,13 +1,21 @@
 package kafka
 
 import (
+	"flag"
 	"sync"
 
 	"github.com/op/go-logging"
 )
 
-var log *logging.Logger
-var logMu = &sync.Mutex{}
+var (
+	log *logging.Logger
+	logMu = &sync.Mutex{}
+
+	logLevel = flag.Int(
+		"kafka.log_level",
+		int(logging.INFO),
+		"Set logging verbosity for Kafka client.")
+)
 
 func init() {
 	logMu.Lock()
@@ -17,7 +25,7 @@ func init() {
 		return
 	}
 	log = logging.MustGetLogger("KafkaClient")
-	logging.SetLevel(logging.INFO, "KafkaClient")
+	logging.SetLevel(logging.Level(*logLevel), "KafkaClient")
 }
 
 func SetLogger(l *logging.Logger) {


### PR DESCRIPTION
Add a flag to set logging levels for the kafka and kafkatest package. 

We'd like to be able to control how verbose the mock kafka client is when using it in tests.