### PR TITLE
Remove unused RetryLimit and RetryWait producer configuration entries

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -458,17 +458,6 @@ type ProducerConf struct {
 	// Setting this to any other, greater than zero value will make producer to
 	// wait for given number of servers to confirm write before returning.
 	RequiredAcks int16
-
-	// RetryLimit specify how many times message producing should be retried in
-	// case of failure, before returning the error to the caller. By default
-	// set to 10.
-	RetryLimit int
-
-	// RetryWait specify wait duration before produce retry after failure. This
-	// is subject to exponential backoff.
-	//
-	// Defaults to 200ms.
-	RetryWait time.Duration
 }
 
 // NewProducerConf returns a default producer configuration.
@@ -477,8 +466,6 @@ func NewProducerConf() ProducerConf {
 		Compression:    proto.CompressionNone,
 		RequestTimeout: 5 * time.Second,
 		RequiredAcks:   proto.RequiredAcksAll,
-		RetryLimit:     10,
-		RetryWait:      200 * time.Millisecond,
 	}
 }
 
@@ -497,10 +484,8 @@ func (b *Broker) Producer(conf ProducerConf) Producer {
 }
 
 // Produce writes messages to the given destination. Writes within the call are
-// atomic, meaning either all or none of them are written to kafka.  Produce
-// has a configurable amount of retries which may be attempted when common
-// errors are encountered.  This behaviour can be configured with the
-// RetryLimit and RetryWait attributes.
+// atomic, meaning either all or none of them are written to kafka. Produce does not
+// retry in the case of failure.
 //
 // Upon a successful call, the message's Offset field is updated.
 func (p *producer) Produce(

--- a/broker_test.go
+++ b/broker_test.go
@@ -259,7 +259,6 @@ func (s *BrokerSuite) TestProducer(c *C) {
 	c.Assert(err, IsNil)
 
 	prodConf := NewProducerConf()
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 	messages := []*proto.Message{
 		{Value: []byte("first")},
@@ -328,7 +327,6 @@ func (s *BrokerSuite) TestProducerWithNoAck(c *C) {
 
 	prodConf := NewProducerConf()
 	prodConf.RequiredAcks = proto.RequiredAcksNone
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 	messages := []*proto.Message{
 		{Value: []byte("first")},
@@ -1635,8 +1633,6 @@ func (s *BrokerSuite) TestProducerFailoverRequestTimeout(c *C) {
 	c.Assert(err, IsNil)
 
 	prodConf := NewProducerConf()
-	prodConf.RetryLimit = 4
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 
 	_, err = producer.Produce(
@@ -1703,8 +1699,6 @@ func (s *BrokerSuite) TestProducerFailoverLeaderNotAvailable(c *C) {
 	c.Assert(err, IsNil)
 
 	prodConf := NewProducerConf()
-	prodConf.RetryLimit = 5
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 
 	for try := 0; try < numTriesRequired; try++ {
@@ -1765,8 +1759,6 @@ func (s *BrokerSuite) TestProducerNoCreateTopic(c *C) {
 	c.Assert(err, IsNil)
 
 	prodConf := NewProducerConf()
-	prodConf.RetryLimit = 5
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 
 	_, err = producer.Produce(
@@ -1818,8 +1810,6 @@ func (s *BrokerSuite) TestProducerTryCreateTopic(c *C) {
 	c.Assert(err, IsNil)
 
 	prodConf := NewProducerConf()
-	prodConf.RetryLimit = 5
-	prodConf.RetryWait = time.Millisecond
 	producer := broker.Producer(prodConf)
 
 	_, err = producer.Produce("test2", 0, &proto.Message{Value: []byte("first")},
@@ -2187,7 +2177,6 @@ To get the error EPIPE, you need to send large amount of data after closing the 
 	`, 1000))
 
 	pconf := NewProducerConf()
-	pconf.RetryWait = time.Millisecond
 	pconf.RequestTimeout = time.Millisecond * 20
 	producer := broker.Producer(pconf)
 	waitForMetadataEpoch(c, producer, 1)


### PR DESCRIPTION
Hello, we're using this library at Gusto. I dug into the code at one point to better understand something, and noticed that the `ProducerConf` type defined fields `RetryLimit` and `RetryWait` that aren't used anywhere. Before I realized they weren't used, it was quite confusing and misleading. I'd like to remove the properties altogether to prevent confusion for others.

Please let me know if these fields are actually used in some place I missed.